### PR TITLE
Log to run directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 *.swp
 *.coverage
 *.bak
-*.log
 docs/_build/*
 build/
 .virtualenv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Added functionality:
 * When uploading, a `irida_uploader_status.info` status file will be created in the run directory
 * If a status file exists, trying to upload will fail and give a message saying an upload has already been attempted
 * using `--force` or `-f` when uploading bypasses this check
+* Now uploader writes logs to run folder, for that specific upload
 
 Beta 0.1
 ---------

--- a/core/cli_entry.py
+++ b/core/cli_entry.py
@@ -7,7 +7,7 @@ import parsers
 import global_settings
 import progress
 
-from . import api_handler, parsing_handler
+from . import api_handler, parsing_handler, logger
 
 EXIT_CODE_ERROR = 1
 EXIT_CODE_SUCCESS = 0
@@ -27,7 +27,7 @@ def validate_and_upload_single_entry(directory, force_upload=False):
     :param force_upload: When set to true, the upload status file will be ignored and file will attempt to be uploaded
     :return:
     """
-    logging_start_block()
+    logging_start_block(directory)
     logging.debug("validate_and_upload_single_entry:Starting {}".format(directory))
 
     # Only upload if run is new, or force_upload is True
@@ -142,12 +142,13 @@ def exit_success():
     return EXIT_CODE_SUCCESS
 
 
-def logging_start_block():
+def logging_start_block(directory):
     """
     Logs an information block to the console and file which indicates the start of an upload run.
     Includes the uploader version number set in the global_settings module
     :return:
     """
+    logger.add_log_to_directory(directory)
     logging.info("==================================================")
     logging.info("---------------STARTING UPLOAD RUN----------------")
     logging.info("Uploader Version {}".format(global_settings.UPLOADER_VERSION))
@@ -163,3 +164,5 @@ def logging_end_block():
     logging.info("==================================================")
     logging.info("----------------ENDING UPLOAD RUN-----------------")
     logging.info("==================================================")
+    logger.remove_directory_logger()
+

--- a/core/logger.py
+++ b/core/logger.py
@@ -47,11 +47,18 @@ root_logger.addHandler(console)
 
 global_settings.log_file = user_log_dir(log_directory_name)
 
-
+# manages the logging directory
+# only one directory can have a logger at a time
 directory_logger = None
 
 
 def add_log_to_directory(directory):
+    """
+    Starts up a logging handler that creates a log file in the directory being uploaded
+
+    :param directory: directory to create a logger in
+    :return: None
+    """
     logging.info("Adding log file to {}".format(directory))
     log_file = os.path.join(directory, 'irida-uploader.log')
     global directory_logger
@@ -66,6 +73,11 @@ def add_log_to_directory(directory):
 
 
 def remove_directory_logger():
+    """
+    Deletes the existing directory logger so logging stops
+
+    :return: None
+    """
     global directory_logger
     root_logger.removeHandler(directory_logger)
     logging.info("Stopped active logging to run directory")

--- a/core/logger.py
+++ b/core/logger.py
@@ -59,9 +59,15 @@ def add_log_to_directory(directory):
     :param directory: directory to create a logger in
     :return: None
     """
+    global directory_logger
+
+    # If there is already a directory logger in place, throw an exception
+    if directory_logger:
+        logging.error("A directory logger already exists!")
+        raise Exception("ERROR:add_log_to_directory: A directory logger already exists!")
+
     logging.info("Adding log file to {}".format(directory))
     log_file = os.path.join(directory, 'irida-uploader.log')
-    global directory_logger
     directory_logger = logging.handlers.RotatingFileHandler(
         filename=log_file,
         maxBytes=(1024 * 1024 * 1024 * 10),  # 10GB max file size
@@ -80,4 +86,5 @@ def remove_directory_logger():
     """
     global directory_logger
     root_logger.removeHandler(directory_logger)
+    directory_logger = None
     logging.info("Stopped active logging to run directory")

--- a/core/logger.py
+++ b/core/logger.py
@@ -10,7 +10,7 @@ log_directory_name = "irida_uploader"
 # When running tests, the Makefile creates an environment variable IRIDA_UPLOADER_TEST to 'True'
 # If it exists then we are running a test and should be logging to the test logs directory
 if os.environ.get('IRIDA_UPLOADER_TEST'):
-        log_directory_name = "irida_uploader_test"
+    log_directory_name = "irida_uploader_test"
 # Use systems default logging path, and append our named directory
 log_file_path = os.path.join(user_log_dir(log_directory_name), 'irida-uploader.log')
 
@@ -25,15 +25,15 @@ log_format = logging.Formatter('%(asctime)s %(levelname)-8s %(message)s', datefm
 root_logger = logging.getLogger()
 root_logger.handlers = []
 logging.basicConfig(
-        level=logging.NOTSET,  # Default to highest (NOTSET) level, so everything is possible to be logged by handlers
-        handlers=[logging.NullHandler()]  # Default log to Null, so that we can handle it manually
+    level=logging.NOTSET,  # Default to highest (NOTSET) level, so everything is possible to be logged by handlers
+    handlers=[logging.NullHandler()]  # Default log to Null, so that we can handle it manually
 )
 
 # Log to file
 rotating_file_handler = logging.handlers.RotatingFileHandler(
-        filename=log_file_path,
-        maxBytes=(1024 * 1024 * 1024 * 10),  # 10GB max file size
-        backupCount=100,
+    filename=log_file_path,
+    maxBytes=(1024 * 1024 * 1024 * 10),  # 10GB max file size
+    backupCount=100,
 )
 rotating_file_handler.setLevel(logging.DEBUG)
 rotating_file_handler.setFormatter(log_format)
@@ -46,3 +46,26 @@ console.setFormatter(log_format)
 root_logger.addHandler(console)
 
 global_settings.log_file = user_log_dir(log_directory_name)
+
+
+directory_logger = None
+
+
+def add_log_to_directory(directory):
+    logging.info("Adding log file to {}".format(directory))
+    log_file = os.path.join(directory, 'irida-uploader.log')
+    global directory_logger
+    directory_logger = logging.handlers.RotatingFileHandler(
+        filename=log_file,
+        maxBytes=(1024 * 1024 * 1024 * 10),  # 10GB max file size
+        backupCount=100,
+    )
+    directory_logger.setLevel(logging.INFO)
+    directory_logger.setFormatter(log_format)
+    root_logger.addHandler(directory_logger)
+
+
+def remove_directory_logger():
+    global directory_logger
+    root_logger.removeHandler(directory_logger)
+    logging.info("Stopped active logging to run directory")

--- a/docs/index.md
+++ b/docs/index.md
@@ -114,7 +114,9 @@ You can edit this file to set a runs status to `new` to reupload, or use the `--
 
 ## Logging
 
-Logs are written to your system default logging directory
+Logs about individual runs are written to the sequencing run directory that they are uploaded from.
+
+Full debug logs are written to your system default logging directory
 
 #### Linux
 

--- a/tests_integration/test_end_to_end.py
+++ b/tests_integration/test_end_to_end.py
@@ -17,12 +17,12 @@ path_to_module = path.dirname(__file__)
 if len(path_to_module) == 0:
     path_to_module = '.'
 
-status_file_list = [
-    path.join(path_to_module, "fake_dir_data", "irida_uploader_status.info"),
-    path.join(path_to_module, "fake_ngs_data", "irida_uploader_status.info"),
-    path.join(path_to_module, "fake_ngs_data_force", "irida_uploader_status.info"),
-    path.join(path_to_module, "fake_ngs_data_nonexistent_project", "irida_uploader_status.info"),
-    path.join(path_to_module, "fake_ngs_data_parse_fail", "irida_uploader_status.info")
+CLEANUP_DIRECTORY_LIST = [
+    path.join(path_to_module, "fake_dir_data"),
+    path.join(path_to_module, "fake_ngs_data"),
+    path.join(path_to_module, "fake_ngs_data_force"),
+    path.join(path_to_module, "fake_ngs_data_nonexistent_project"),
+    path.join(path_to_module, "fake_ngs_data_parse_fail")
 ]
 
 
@@ -48,9 +48,13 @@ class TestEndToEnd(unittest.TestCase):
         """
         self.write_to_config_file("", "", "", "", "", "")
 
-        for status_file_path in status_file_list:
+        for directory_path in CLEANUP_DIRECTORY_LIST:
+            status_file_path = path.join(directory_path, 'irida_uploader_status.info')
             if path.exists(status_file_path):
                 os.remove(status_file_path)
+            log_file_path = path.join(directory_path, 'irida-uploader.log')
+            if path.exists(log_file_path):
+                os.remove(log_file_path)
 
     @staticmethod
     def write_to_config_file(client_id, client_secret, username, password, base_url, parser):


### PR DESCRIPTION
In addition to the regular log files, we now log to the upload run directory too.
Logging is now done with rotating file handlers
Modified the tests to support the new functionality and clean up log files
Also fixed some spacing issues in the logger file