### PR TITLE
added issue and PR templates for irida uploader

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/1_bug_report.md
@@ -1,0 +1,24 @@
+---
+name: Bug report
+about: Report an issue you've found with the IRIDA uploader.
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+## Describe the bug
+Briefly describe the issue you encountered.
+
+## Steps to reproduce the problem
+What were you doing when you encountered the problem?
+1. 
+2. 
+3. 
+
+## Expected behaviour
+What did you expect to happen?
+
+
+## Additional context
+Additional information to help solve the problem.  Test files, screenshots, IRIDA/uploader version information can go here.

--- a/.github/ISSUE_TEMPLATE/2_feature_request.md
+++ b/.github/ISSUE_TEMPLATE/2_feature_request.md
@@ -1,0 +1,14 @@
+---
+name: Feature request
+about: Suggest an idea or new feature for the IRIDA uploader.
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+## Describe your idea for a new feature
+What is the feature you would like to see in the IRIDA uploader?
+
+## Additional information
+Add any other context, files, or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/3_developer_request.md
+++ b/.github/ISSUE_TEMPLATE/3_developer_request.md
@@ -1,0 +1,20 @@
+---
+name: Development fixes
+about: Fixes for the IRIDA uploader's codebase to make the developer's life easier and the codebase cleaner.  Refactors, new modules, etc.
+title: ''
+labels: developer
+assignees: ''
+
+---
+
+## What needs changed?
+What is the IRIDA uploader code component that needs added, updated or refactored?
+
+## How does it work now?
+How does this component work now, and what's wrong with it?
+
+## How should it work?
+How do you think this component should work?
+
+## Additional information
+Add any other context, files, or screenshots about this request here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+## Description of changes
+What did you change in this pull request?  Provide a description of files changed, user interactions changed, etc.  Include how to test your changes.
+
+## Related issue
+Link to the GitHub issue this pull request addresses using the `#issuenum` format.  If it completes an issue, use `Fixes #issuenum` to automatically close the issue.
+
+## Checklist
+Things for the developer to confirm they've done before the PR should be accepted:
+
+* [ ] CHANGELOG.md updated with information for new change.
+* [ ] Tests added (or description of how to test) for any new features.
+* [ ] User documentation updated for UI or technical changes.


### PR DESCRIPTION
Added issue and PR templates for the IRIDA uploader github repository.  These are very similar to the IRIDA templates (https://github.com/phac-nml/irida) but reworded for the uploader.