### PR TITLE
Config overrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,5 @@ site/
 .python-version
 .pytest_cache/
 tests_integration/repos/
-
+irida-uploader.log
+irida_uploader_status.info

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Changes
 
 Beta 0.3
 --------
+Added functionality:
+* Added config option overrides for the command line
+    * Can define in command line `--option parameter` or without a parameter `--option` for a user prompt
+    * Use the `--help` option for more details on these options
 
 Beta 0.2
 --------

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1,1 +1,1 @@
-from config.config import read_config_option, write_config_option, setup
+from config.config import setup, read_config_option, set_config_options, write_config_options_to_file, set_config_file

--- a/config/config.py
+++ b/config/config.py
@@ -5,74 +5,168 @@ from configparser import RawConfigParser, NoOptionError
 from appdirs import user_config_dir
 from collections import namedtuple
 
-import global_settings
+_conf_parser = None
+_user_config_file = None
 
-conf_parser = None
-user_config_file = None
+_default_user_config_file_path = os.path.join(user_config_dir("irida-uploader"), "config.conf")
 
 
-def setup():
+def set_config_file(config_file):
     """
-    Initialize and setup components for the configuration file
-    :return:
+    Public function to allow other modules to change the config file
+    This does not load the settings into the config parser
+    :param config_file: 
+    :return: 
     """
+    global _user_config_file
+    _user_config_file = config_file
 
-    global conf_parser
-    global user_config_file
-    # If a config file was passed as a parameter, use it, else use the default config directory
-    if global_settings.config_file:
-        user_config_file = global_settings.config_file
-        if not os.path.exists(user_config_file):
-            logging.error("Could not find config file: {}".format(user_config_file))
-            exit(1)
-    else:
-        user_config_file = os.path.join(user_config_dir("irida-uploader"), "config.conf")
 
-    conf_parser = RawConfigParser()
-    logging.debug("User config file: " + user_config_file)
+def _init_config_parser():
+    """
+    Creates the RawConfigParser object, adds the fields and fills with default/empty values
+    :return: 
+    """
+    global _conf_parser
+    # Create a new config parser
+    _conf_parser = RawConfigParser()
+    # Put all options under a Settings Header
+    _conf_parser.add_section("Settings")
 
-    # Set defaults for settings if file does not already exist
+    # Create defaults tuple
     SettingsDefault = namedtuple('SettingsDefault', ['setting', 'default_value'])
-
     default_settings = [SettingsDefault._make(["client_id", ""]),
                         SettingsDefault._make(["client_secret", ""]),
                         SettingsDefault._make(["username", ""]),
                         SettingsDefault._make(["password", ""]),
                         SettingsDefault._make(["base_url", ""]),
                         SettingsDefault._make(["parser", "directory"])]
+    # add defaults to config parser
+    for config in default_settings:
+        _conf_parser.set("Settings", config.setting, config.default_value)
 
-    load_from_file = os.path.exists(user_config_file)
-    # Loading config from file
-    if load_from_file:
-        try:
-            logging.debug("Loading configuration settings from {}".format(user_config_file))
 
-            conf_parser.read(user_config_file)
+def _create_new_config_file():
+    """
+    Tries to create a new config file
+    Exit's if the file already exists, or a user config file is already set
+    This only gets used to create a fresh default configuration file
+    Fills the new file with defaults
+    :return:
+    """
+    global _user_config_file
+    if _user_config_file is not None:
+        logging.error("Trying to create new config file when config file as already been set. Exiting")
+        exit(1)
 
-            for config in default_settings:
-                if not conf_parser.has_option("Settings", config.setting):
-                    conf_parser.set("Settings", config.setting, config.default_value)
-        except:
-            logging.warning("Error occurred when trying to load config file")
-            logging.error("Config file {} is not valid.".format(user_config_file))
-            exit(1)
+    _user_config_file = _default_user_config_file_path
 
-    # Create a new user config file and fill with defaults
-    if not load_from_file:
-        logging.info("Creating a new config file.")
-        conf_parser.add_section("Settings")
+    # Create path to file if it doesn't exit yet
+    if not os.path.exists(os.path.dirname(_user_config_file)):
+        os.makedirs(os.path.dirname(_user_config_file))
+    # exit if the file already exists
+    if os.path.exists(_user_config_file):
+        logging.error("File already exits, cannot create a new file")
+        exit(1)
 
-        if not os.path.exists(os.path.dirname(user_config_file)):
-            os.makedirs(os.path.dirname(user_config_file))
+    # init the config parser with default values
+    global _conf_parser
+    with open(_user_config_file, 'w') as config_file:
+        _conf_parser.write(config_file)
 
-        for config in default_settings:
-            conf_parser.set("Settings", config.setting, config.default_value)
+    logging.info("Config File Created: " + str(_user_config_file))
+    logging.info("Please edit your config file to connect to IRIDA")
 
-        with open(user_config_file, 'w') as config_file:
-            conf_parser.write(config_file)
 
-        logging.info("Config File Created: " + str(user_config_file))
-        logging.info("Please edit your config file to connect to IRIDA")
+def _load_config_from_file():
+    """
+    Verifies file exists, and loads data from file into the config parser
+    :return:
+    """
+    global _user_config_file
+
+    if not os.path.exists(_user_config_file):
+        logging.error("Config File {} does not exist, exiting".format(_user_config_file))
+        exit(1)
+
+    try:
+        _conf_parser.read(_user_config_file)
+    except:
+        logging.warning("Error occurred when trying to load config file")
+        logging.error("Config file {} is not valid.".format(_user_config_file))
+        exit(1)
+
+    logging.info("Config loaded from file {}".format(_user_config_file))
+
+
+def set_config_options(client_id=None,
+                       client_secret=None,
+                       username=None,
+                       password=None,
+                       base_url=None,
+                       parser=None):
+    """
+    Updates the config options for all not None parameters
+    :param client_id:
+    :param client_secret:
+    :param username:
+    :param password:
+    :param base_url:
+    :param parser:
+    :return:
+    """
+    global _conf_parser
+    if _conf_parser is None:
+        logging.error("Config Parser has not been init, exiting")
+        exit(1)
+
+    if client_id:
+        logging.debug("Setting 'client_id' config to {}".format(client_id))
+        _update_config_option("client_id", client_id)
+    if client_secret:
+        logging.debug("Setting 'client_secret' config to {}".format(client_secret))
+        _update_config_option("client_secret", client_secret)
+    if username:
+        logging.debug("Setting 'username' config to {}".format(username))
+        _update_config_option("username", username)
+    if password:
+        logging.debug("Setting 'password' config")
+        _update_config_option("password", password)
+    if base_url:
+        logging.debug("Setting 'base_url' config to {}".format(base_url))
+        _update_config_option("base_url", base_url)
+    if parser:
+        logging.debug("Setting 'parser' config to {}".format(parser))
+        _update_config_option("parser", parser)
+
+
+def setup():
+    """
+    Initialize and setup components for the configuration file
+    Creates a new conf parser, and loads from user_config_file or default config file
+    If the default file is used but doesn't exist, it will be created and the program will exit
+    :return:
+    """
+    global _conf_parser
+    global _user_config_file
+    global _default_user_config_file_path
+
+    _init_config_parser()
+    # If a config file is set, inform user
+    if _user_config_file:
+        logging.info("Config file set to {}".format(_user_config_file))
+    # If a config file was not set, create a new file
+    elif not os.path.exists(_default_user_config_file_path):
+        logging.info("No config file found, creating a new file {}".format(_default_user_config_file_path))
+        _create_new_config_file()
+        exit(1)
+    # Use the default file as the user config file
+    else:
+        logging.info("Using default config file {}".format(_default_user_config_file_path))
+        _user_config_file = _default_user_config_file_path
+
+    # Load from file
+    _load_config_from_file()
 
 
 def read_config_option(key, expected_type=None, default_value=None):
@@ -87,32 +181,39 @@ def read_config_option(key, expected_type=None, default_value=None):
     """
     logging.debug("Reading config option {} with expected type {}".format(key, expected_type))
 
-    global conf_parser
+    global _conf_parser
     try:
         if not expected_type:
-            value = conf_parser.get("Settings", key)
+            value = _conf_parser.get("Settings", key)
             logging.debug("Got configuration for key {}: {}".format(key, value))
-            return conf_parser.get("Settings", key)
+            return _conf_parser.get("Settings", key)
         elif expected_type is bool:
-            return conf_parser.getboolean("Settings", key)
-    except (ValueError, NoOptionError) as e:
+            return _conf_parser.getboolean("Settings", key)
+    except (ValueError, NoOptionError):
         if default_value:
             return default_value
         else:
             raise
 
 
-def write_config_option(field_name, field_value):
+def _update_config_option(field_name, field_value):
     """
-    Writes an option to the configuration file.
-
+    Sets an option in the config parser (Does not write to file)
     :param field_name: Field to change the value of
-    :param field_value: Value to write to file
+    :param field_value: Value to change to
+    :return:
+    """
+    global _conf_parser
+    _conf_parser.set("Settings", field_name, field_value)
+
+
+def write_config_options_to_file():
+    """
+    Writes all options in the config parser to config file
+
     :return: None
     """
-    global conf_parser
-    global user_config_file
-    conf_parser.set("Settings", field_name, field_value)
-
-    with open(user_config_file, 'w') as c_file:
-        conf_parser.write(c_file)
+    global _conf_parser
+    global _user_config_file
+    with open(_user_config_file, 'w') as c_file:
+        _conf_parser.write(c_file)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -54,6 +54,29 @@ Example:
   C:\Users\username> iridauploader --config \path\to\config.conf \path\to\my\samples\
 ```
 
-### Linux:
+## Override config options in file
 
-Use the `irida-uploader.sh` script included with the source code to upload.
+You can override one or more config options with their respective command line arguments
+
+This can be done as given parameters `--option parameter` or via user prompt `--option`
+
+```bash
+  -ci [CONFIG_CLIENT_ID], --config_client_id [CONFIG_CLIENT_ID]
+                        Override "client_id" in config file. Can be used
+                        without a parameter to prompt for input.
+  -cs [CONFIG_CLIENT_SECRET], --config_client_secret [CONFIG_CLIENT_SECRET]
+                        Override "client_secret" in config file. Can be used
+                        without a parameter to prompt for input.
+  -cu [CONFIG_USERNAME], --config_username [CONFIG_USERNAME]
+                        Override "username" in config file. Can be used
+                        without a parameter to prompt for input.
+  -cp [CONFIG_PASSWORD], --config_password [CONFIG_PASSWORD]
+                        Override "password" in config file. Can be used
+                        without a parameter to prompt for input.
+  -cb [CONFIG_BASE_URL], --config_base_url [CONFIG_BASE_URL]
+                        Override "base_url" in config file. Can be used
+                        without a parameter to prompt for input.
+  -cr [CONFIG_PARSER], --config_parser [CONFIG_PARSER]
+                        Override "parser" in config file. Can be used without
+                        a parameter to prompt for input.
+```

--- a/global_settings.py
+++ b/global_settings.py
@@ -1,10 +1,7 @@
 """
 This file manages globals across files.
-
-It is used to handle passing a config file as a parameter
 """
 
 UPLOADER_VERSION = "0.3"
 
-config_file = None
 log_file = None

--- a/parsers/__init__.py
+++ b/parsers/__init__.py
@@ -1,2 +1,2 @@
-from .parsers import Parser
+from .parsers import Parser, supported_parsers
 from . import exceptions

--- a/parsers/parsers.py
+++ b/parsers/parsers.py
@@ -2,6 +2,12 @@ import logging
 
 from . import directory, miseq, miniseq, nextseq
 
+supported_parsers = [
+    'miseq',
+    'miniseq',
+    'nextseq',
+    'directory',
+]
 
 class Parser:
     """

--- a/tests_integration/test_end_to_end.py
+++ b/tests_integration/test_end_to_end.py
@@ -4,7 +4,6 @@ import os
 
 from tests_integration import tests_integration
 
-import global_settings
 import config
 import api
 import model
@@ -42,7 +41,7 @@ class TestEndToEnd(unittest.TestCase):
     def setUp(self):
         print("\nStarting " + self.__module__ + ": " + self._testMethodName)
         # Set the config file to our test config, so that when the upload is run it grabs out config file correctly
-        global_settings.config_file = path.join(path_to_module, "test_config.conf")
+        config.set_config_file(path.join(path_to_module, "test_config.conf"))
         config.setup()
 
     def tearDown(self):
@@ -74,12 +73,13 @@ class TestEndToEnd(unittest.TestCase):
         :param parser:
         :return:
         """
-        config.write_config_option("client_id", client_id)
-        config.write_config_option("client_secret", client_secret)
-        config.write_config_option("username", username)
-        config.write_config_option("password", password)
-        config.write_config_option("base_url", base_url)
-        config.write_config_option("parser", parser)
+        config.set_config_options(client_id=client_id,
+                                  client_secret=client_secret,
+                                  username=username,
+                                  password=password,
+                                  base_url=base_url,
+                                  parser=parser)
+        config.write_config_options_to_file()
 
     def test_valid_miseq_upload(self):
         """

--- a/upload_run.py
+++ b/upload_run.py
@@ -1,45 +1,12 @@
 #!/usr/bin/env python3
 
 import argparse
+import getpass
 import os
 
 import config
 import core
 import global_settings
-
-
-class ConfigAction(argparse.Action):
-    """
-    This class is called when a config option is passed to via command line.
-
-    It sets the global_settings config_file option to whatever was passed in the argument
-    """
-    def __init__(self, option_strings, dest, nargs=None, **kwargs):
-        """
-        Boilerplate for an argparse Action
-
-        :param option_strings: A list of command-line option strings which
-            should be associated with this action.
-        :param dest: The name of the attribute to hold the created object(s)
-        :param nargs: The number of command-line arguments that should be
-            consumed. See argparse docs for details
-        :param kwargs: All other options. See argparse docs for details
-        """
-        if nargs is not None:
-            raise ValueError("nargs not allowed")
-        super(ConfigAction, self).__init__(option_strings, dest, **kwargs)
-
-    def __call__(self, parser, namespace, values, option_string=None):
-        """
-        Gets executed when the argument is included from the command line
-
-        :param parser: Not used.
-        :param namespace: Not used.
-        :param values: The value passed via the command line. The global config_file variable will be set to this.
-        :param option_string: not used
-        :return: None
-        """
-        global_settings.config_file = values
 
 
 # Set up an argument parser. We are using defaults to stay consistent with other software.
@@ -53,7 +20,7 @@ argument_parser.add_argument('directory',
                              help='Location of sequencing run to upload. Directory must be writable.')
 # Optional argument, for using an alternative config file.
 argument_parser.add_argument('-c', '--config',
-                             action=ConfigAction,
+                             action='store',
                              help='Path to an alternative configuration file. '
                                   'This overrides the default config file in the config directory')
 # Optional argument, Force uploading a run even if a non new status file exists
@@ -69,14 +36,119 @@ argument_parser.add_argument('-b', '--batch',
                                   'The list of runs is generated at start time '
                                   '(Runs added to directory mid upload will not be uploaded).')
 
+# Optional arguments for overriding config file settings
+# Explanation:
+#   nargs='?', const=True, default=False,
+#       Allows zero or one parameters
+#       If the argument is not given:                      the value will be False           (indicates load from file)
+#       If the argument is given, and no parameter given:  the value will be True            (prompt user for input)
+#       If the argument is given, and parameter is given:  the value will be the parameter   (used to override config)
+argument_parser.add_argument('-ci', '--config_client_id', action='store', nargs='?', const=True, default=False,
+                             help='Override "client_id" in config file. '
+                                  'Can be used without a parameter to prompt for input.')
+argument_parser.add_argument('-cs', '--config_client_secret', action='store', nargs='?', const=True, default=False,
+                             help='Override "client_secret" in config file. '
+                                  'Can be used without a parameter to prompt for input.')
+argument_parser.add_argument('-cu', '--config_username', action='store', nargs='?', const=True, default=False,
+                             help='Override "username" in config file. '
+                                  'Can be used without a parameter to prompt for input.')
+argument_parser.add_argument('-cp', '--config_password', action='store', nargs='?', const=True, default=False,
+                             help='Override "password" in config file. '
+                                  'Can be used without a parameter to prompt for input.')
+argument_parser.add_argument('-cb', '--config_base_url', action='store', nargs='?', const=True, default=False,
+                             help='Override "base_url" in config file. '
+                                  'Can be used without a parameter to prompt for input.')
+argument_parser.add_argument('-cr', '--config_parser', action='store', nargs='?', const=True, default=False,
+                             help='Override "parser" in config file. '
+                                  'Can be used without a parameter to prompt for input.')
+
+
+def _set_config_override(args):
+    """
+    Check the config override arguments and override
+    :param args: list of args from parseargs
+    :return:
+    """
+    client_id = None
+    client_secret = None
+    username = None
+    password = None
+    base_url = None
+    parser = None
+
+    if args.config_client_id is True:
+        print("Enter Client ID:")
+        client_id = input()
+    elif args.config_client_id is not False:
+        client_id = args.config_client_id
+
+    if args.config_client_secret is True:
+        print("Enter Client Secret:")
+        client_secret = input()
+    elif args.config_client_secret is not False:
+        client_secret = args.config_client_secret
+
+    if args.config_username is True:
+        print("Enter Username:")
+        username = input()
+    elif args.config_username is not False:
+        username = args.config_username
+
+    if args.config_password is True:
+        print("Enter Password:")
+        # getpass blanks out password entry
+        password = getpass.getpass()
+    elif args.config_password is not False:
+        password = args.config_password
+
+    if args.config_base_url is True:
+        print("Enter Base IRIDA URL (format: http://my.irida.server/api/):")
+        base_url = input()
+    elif args.config_base_url is not False:
+        base_url = args.config_base_url
+
+    if args.config_parser is True:
+        print("Enter Parser to use:")
+        parser = input()
+    elif args.config_parser is not False:
+        parser = args.config_parser
+
+    config.set_config_options(client_id=client_id,
+                              client_secret=client_secret,
+                              username=username,
+                              password=password,
+                              base_url=base_url,
+                              parser=parser)
+
+
+def _config_uploader(args):
+    """
+    Sets up config settings for command line uploading
+    :param args:
+    :return:
+    """
+    # If a config file is passed in, set it before starting upload
+    if args.config:
+        config.set_config_file(args.config)
+        # config.user_config_file = args.config
+    # Init config
+    config.setup()
+    # Override with any passed in options
+    _set_config_override(args)
+
 
 def main():
     # Parse the arguments passed from the command line and start the upload
     args = argument_parser.parse_args()
-    directory = args.directory
-    if not os.access(directory, os.W_OK):  # Cannot access upload directory
-        print("ERROR! Specified directory is not writable: {}".format(directory))
+    # Setup config options
+    _config_uploader(args)
+
+    # Verify directory is writable before upload
+    if not os.access(args.directory, os.W_OK):  # Cannot access upload directory
+        print("ERROR! Specified directory is not writable: {}".format(args.directory))
         return 1
+
+    # Start Upload
     if args.batch:
         return upload_batch(args.directory, args.force)
     else:
@@ -90,7 +162,6 @@ def upload(run_directory, force_upload):
     :param force_upload:
     :return:
     """
-    config.setup()
     return core.cli_entry.upload_run_single_entry(run_directory, force_upload)
 
 
@@ -101,7 +172,6 @@ def upload_batch(batch_directory, force_upload):
     :param force_upload:
     :return:
     """
-    config.setup()
     return core.cli_entry.batch_upload_single_entry(batch_directory, force_upload)
 
 

--- a/upload_run.py
+++ b/upload_run.py
@@ -7,13 +7,14 @@ import os
 import config
 import core
 import global_settings
-
+from parsers import supported_parsers
 
 # Set up an argument parser. We are using defaults to stay consistent with other software.
 # description gets added to the usage statements
-argument_parser = argparse.ArgumentParser(description='This program parses sequencing runs and uploads them to IRIDA.')
+argument_parser = argparse.ArgumentParser(description='This program parses sequencing runs and uploads them to IRIDA.',
+                                          epilog='-c* options can be used without a parameter to prompt for input.')
 # Add the version argument
-argument_parser.add_argument('-v', '--version',
+argument_parser.add_argument('--version',
                              action='version', version='IRIDA Uploader {}'.format(global_settings.UPLOADER_VERSION))
 # Our main argument. It is required or else an error will be thrown when the program is run
 argument_parser.add_argument('directory',
@@ -44,23 +45,22 @@ argument_parser.add_argument('-b', '--batch',
 #       If the argument is given, and no parameter given:  the value will be True            (prompt user for input)
 #       If the argument is given, and parameter is given:  the value will be the parameter   (used to override config)
 argument_parser.add_argument('-ci', '--config_client_id', action='store', nargs='?', const=True, default=False,
-                             help='Override "client_id" in config file. '
-                                  'Can be used without a parameter to prompt for input.')
+                             help='Override the "client_id" field in config file. '
+                                  'This is for the uploader client created in IRIDA, used to handle the data upload')
 argument_parser.add_argument('-cs', '--config_client_secret', action='store', nargs='?', const=True, default=False,
                              help='Override "client_secret" in config file. '
-                                  'Can be used without a parameter to prompt for input.')
+                                  'This is for the uploader client created in IRIDA, used to handle the data upload')
 argument_parser.add_argument('-cu', '--config_username', action='store', nargs='?', const=True, default=False,
-                             help='Override "username" in config file. '
-                                  'Can be used without a parameter to prompt for input.')
+                             help='Override "username" in config file. This is your IRIDA account username.')
 argument_parser.add_argument('-cp', '--config_password', action='store', nargs='?', const=True, default=False,
-                             help='Override "password" in config file. '
-                                  'Can be used without a parameter to prompt for input.')
+                             help='Override "password" in config file. This corresponds to your IRIDA account.')
 argument_parser.add_argument('-cb', '--config_base_url', action='store', nargs='?', const=True, default=False,
-                             help='Override "base_url" in config file. '
-                                  'Can be used without a parameter to prompt for input.')
+                             help='Override "base_url" in config file. The api url for your irida instance '
+                                  '(example: https://my.irida.server/api/)')
 argument_parser.add_argument('-cr', '--config_parser', action='store', nargs='?', const=True, default=False,
                              help='Override "parser" in config file. '
-                                  'Can be used without a parameter to prompt for input.')
+                                  'Choose the type of sequencer data that is being uploaded. '
+                                  'Supported parsers: ' + str(supported_parsers))
 
 
 def _set_config_override(args):
@@ -84,7 +84,8 @@ def _set_config_override(args):
 
     if args.config_client_secret is True:
         print("Enter Client Secret:")
-        client_secret = input()
+        # getpass blanks out the secret entry
+        client_secret = getpass.getpass()
     elif args.config_client_secret is not False:
         client_secret = args.config_client_secret
 

--- a/upload_run.py
+++ b/upload_run.py
@@ -3,6 +3,7 @@
 import argparse
 import getpass
 import os
+import textwrap
 
 import config
 import core
@@ -11,14 +12,31 @@ from parsers import supported_parsers
 
 # Set up an argument parser. We are using defaults to stay consistent with other software.
 # description gets added to the usage statements
-argument_parser = argparse.ArgumentParser(description='This program parses sequencing runs and uploads them to IRIDA.',
-                                          epilog='-c* options can be used without a parameter to prompt for input.')
+argument_parser = argparse.ArgumentParser(
+    formatter_class=argparse.RawDescriptionHelpFormatter,
+    description=textwrap.dedent('''
+    This program parses sequencing runs and uploads them to IRIDA.
+    
+    required arguments:
+      --d DIRECTORY, --directory DIRECTORY
+                            Location of sequencing run to upload.
+                            Directory must be writable.
+    '''),
+  prog="irida-uploader.sh -d DIRECTORY",
+  epilog='-c* options can be used without a parameter to prompt for input.')
+# Our main argument. It is required or else an error will be thrown when the program is run
+# Normally we would use a positional argument, but because of our 1 or None config overrides it makes sense to use
+# a optional argument, with the required set to True. We have to suppress the help on the argument, and add it's help
+# information to the formatted description text of the parser for the argument to be shown as required when --help
+# is used.
+argument_parser.add_argument('-d','--directory',
+                             action='store',
+                             required=True,
+                             help=argparse.SUPPRESS)
+# help='Location of sequencing run to upload. Directory must be writable.')
 # Add the version argument
 argument_parser.add_argument('--version',
                              action='version', version='IRIDA Uploader {}'.format(global_settings.UPLOADER_VERSION))
-# Our main argument. It is required or else an error will be thrown when the program is run
-argument_parser.add_argument('directory',
-                             help='Location of sequencing run to upload. Directory must be writable.')
 # Optional argument, for using an alternative config file.
 argument_parser.add_argument('-c', '--config',
                              action='store',

--- a/upload_run.py
+++ b/upload_run.py
@@ -22,8 +22,8 @@ argument_parser = argparse.ArgumentParser(
                             Location of sequencing run to upload.
                             Directory must be writable.
     '''),
-  prog="irida-uploader.sh -d DIRECTORY",
-  epilog='-c* options can be used without a parameter to prompt for input.')
+    prog="irida-uploader.sh -d DIRECTORY",
+    epilog='-c* options can be used without a parameter to prompt for input.')
 # Our main argument. It is required or else an error will be thrown when the program is run
 # Normally we would use a positional argument, but because of our 1 or None config overrides it makes sense to use
 # a optional argument, with the required set to True. We have to suppress the help on the argument, and add it's help


### PR DESCRIPTION
## Description of changes
Added config option overrides for the command line
Any config option can be overridden with the respective command line arguments, both in line `--option parameter` or with user prompt `--option`
When a password via user prompt, it will hide input from user.

From the `--help` option: 
```
  -ci [CONFIG_CLIENT_ID], --config_client_id [CONFIG_CLIENT_ID]
                        Override "client_id" in config file. Can be used
                        without a parameter to prompt for input.
  -cs [CONFIG_CLIENT_SECRET], --config_client_secret [CONFIG_CLIENT_SECRET]
                        Override "client_secret" in config file. Can be used
                        without a parameter to prompt for input.
  -cu [CONFIG_USERNAME], --config_username [CONFIG_USERNAME]
                        Override "username" in config file. Can be used
                        without a parameter to prompt for input.
  -cp [CONFIG_PASSWORD], --config_password [CONFIG_PASSWORD]
                        Override "password" in config file. Can be used
                        without a parameter to prompt for input.
  -cb [CONFIG_BASE_URL], --config_base_url [CONFIG_BASE_URL]
                        Override "base_url" in config file. Can be used
                        without a parameter to prompt for input.
  -cr [CONFIG_PARSER], --config_parser [CONFIG_PARSER]
                        Override "parser" in config file. Can be used without
                        a parameter to prompt for input.
```

## Related issue
Fixes #35

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [ ] CHANGELOG.md updated with information for new change.
* [ ] Tests added (or description of how to test) for any new features.
* [ ] User documentation updated for UI or technical changes.
