### PR TITLE
Valid url crash fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,14 @@ Added functionality:
     * Can define in command line `--option parameter` or without a parameter `--option` for a user prompt
     * Use the `--help` option for more details on these options
 
+Bug Fixes:
+* Fixed hard crash that sometimes occurred when valid url's were given as the base_url
+
 Beta 0.2.1
 ----------
 Bug Fixes:
 * Fixed bug where 2 description fields would be sent with some miniseq runs, causing upload to fail.
+
 Beta 0.2
 --------
 Added functionality:

--- a/api/api_calls.py
+++ b/api/api_calls.py
@@ -137,7 +137,13 @@ class ApiCalls(object):
             returns evaluated dictionary
             """
             # It is supposedly safer to decode bytes to string and then use ast.literal_eval than just use eval()
-            irida_dict = ast.literal_eval(return_dict.decode("utf-8"))
+            try:
+                irida_dict = ast.literal_eval(return_dict.decode("utf-8"))
+            except (SyntaxError, ValueError):
+                # SyntaxError happens when something that looks nothing like a token is returned (ex: 404 page)
+                # ValueError happens with the path returns something that looks like a token, but is invalid
+                #   (ex: forgetting the /api/ part of the url)
+                raise ConnectionError("Unexpected response from server, URL may be incorrect")
             return irida_dict
 
         params = {


### PR DESCRIPTION
## Description of changes
Fixed a bug that caused a hard crash when a valid url did not return a properly formatted token

## Related issue
Fixes #3 