### PR TITLE
Miniseq description dup fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changes
 =======
 
+Beta 0.2.1
+----------
+Bug Fixes:
+* Fixed bug where 2 description fields would be sent with some miniseq runs, causing upload to fail.
+
 Beta 0.2
 --------
 Added functionality:

--- a/global_settings.py
+++ b/global_settings.py
@@ -4,7 +4,7 @@ This file manages globals across files.
 It is used to handle passing a config file as a parameter
 """
 
-UPLOADER_VERSION = "0.2"
+UPLOADER_VERSION = "0.2.1"
 
 config_file = None
 log_file = None

--- a/parsers/miniseq/sample_parser.py
+++ b/parsers/miniseq/sample_parser.py
@@ -288,6 +288,9 @@ def _parse_samples(sample_sheet_file):
 
         new_sample_dict = deepcopy(sample_dict)
         new_sample_name = new_sample_dict['sampleName']
+        # Some versions of the illumina *seq software has description fields, and others do not
+        # If they do, we need to include the description field here (or else we end up with duplication of fields)
+        # If they don't we give it a blank description
         new_sample_desc = ''
         if 'Description' in new_sample_dict:
             new_sample_desc = new_sample_dict['description']

--- a/parsers/miniseq/sample_parser.py
+++ b/parsers/miniseq/sample_parser.py
@@ -233,7 +233,8 @@ def _parse_samples(sample_sheet_file):
     sample_key_translation_dict = {
         'Sample_ID': 'sequencer_sample_ID',
         'Sample_Name': 'sampleName',
-        'Sample_Project': 'sample_project'
+        'Sample_Project': 'sample_project',
+        'Description': 'description'
     }
 
     _parse_samples.sample_key_translation_dict = sample_key_translation_dict
@@ -287,11 +288,15 @@ def _parse_samples(sample_sheet_file):
 
         new_sample_dict = deepcopy(sample_dict)
         new_sample_name = new_sample_dict['sampleName']
+        new_sample_desc = ''
+        if 'Description' in new_sample_dict:
+            new_sample_desc = new_sample_dict['description']
 
         sample = model.Sample(
                             sample_name=new_sample_name,
                             sample_number=sample_number + 1,
-                            samp_dict=new_sample_dict)
+                            samp_dict=new_sample_dict,
+                            description=new_sample_desc)
         sample_list.append(sample)
 
     return sample_list

--- a/windows-installer.cfg
+++ b/windows-installer.cfg
@@ -1,6 +1,6 @@
 [Application]
 name=IRIDA Sequence Uploader
-version=0.2
+version=0.2.1
 entry_point=upload_run:main
 icon=images/icon.ico
 # We need to set this to get a console:


### PR DESCRIPTION
## Description of changes
Fixed a bug where the description field on a sample would appear twice as `Description` and `description` on miniseq runs, causing IRIDA to fail to accept the upload when it tried to add the fields in sql. Now they are treated as the same, and parsed correctly.

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [ ] CHANGELOG.md updated with information for new change.
* [ ] Tests added (or description of how to test) for any new features.
* [ ] User documentation updated for UI or technical changes.
