### PR TITLE
fix miniseq parser crashing when trying to read a miseq run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Added functionality:
 
 Bug Fixes:
 * Fixed hard crash that sometimes occurred when valid url's were given as the base_url
+* Fixed hard crash when running the miniseq parser on a miseq run directory
 
 Beta 0.2.1
 ----------

--- a/parsers/miniseq/sample_parser.py
+++ b/parsers/miniseq/sample_parser.py
@@ -126,6 +126,13 @@ def _parse_sample_list(sample_sheet_file):
     sample_list = _parse_samples(sample_sheet_file)
     sample_sheet_dir = path.dirname(sample_sheet_file)
     partial_data_dir = path.join(sample_sheet_dir, "Alignment_1")
+    # Verify the partial path exits, path could not exist if there was a sequencing error
+    # Also, if someone runs the miniseq parser on a miseq directory, this is the failure point
+    if not path.exists(partial_data_dir):
+        raise exceptions.SequenceFileError(
+            ("The uploader was unable to find the data directory with the path: {}, Verify that the run directory is "
+             "undamaged, and that it is a MiniSeq sequencing run.").format(partial_data_dir))
+
     # get the directories [1] get the first directory [0]
     data_dir = path.join(partial_data_dir, next(walk(partial_data_dir))[1][0], "Fastq")
     data_dir_file_list = next(walk(data_dir))[2]  # Create a file list of the data directory, only hit the os once


### PR DESCRIPTION
## Description of changes
fix miniseq parser crashing when trying to read a miseq run

## Related issue
N/A

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [x] CHANGELOG.md updated with information for new change.
* [ ] Tests added (or description of how to test) for any new features.
* [ ] User documentation updated for UI or technical changes.
