### PR TITLE
set quiet logging for maven so tests don't stop running

### DIFF
--- a/tests_integration/integration_data_setup.py
+++ b/tests_integration/integration_data_setup.py
@@ -47,7 +47,7 @@ class SetupIridaData:
         reference_file = "tests_integration/tmp/reference-files"
         sequence_files = "tests_integration/tmp/sequence-files"
 
-        self.IRIDA_CMD = ['mvn', 'clean', 'jetty:run',
+        self.IRIDA_CMD = ['mvn', 'clean', 'jetty:run', '--quiet',
                           '-Djdbc.url=jdbc:mysql://localhost:3306/' + db_name,
                           '-Djdbc.username=test', '-Djdbc.password=test',
                           '-Dliquibase.update.database.schema=true',


### PR DESCRIPTION
## Description of changes
Added the `--quiet` option to the integration tests maven build

## Related issue
N/A

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [ ] CHANGELOG.md updated with information for new change.
* [ ] Tests added (or description of how to test) for any new features.
* [ ] User documentation updated for UI or technical changes.
