### PR TITLE
added support for miseq controll software v3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,8 @@ matrix:
         - echo $JAVA_HOME
         - sudo add-apt-repository ppa:openjdk-r/ppa -y
         - sudo apt-get update
-        - sudo apt-get install openjdk-8-jdk -y
-        - export JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64"
+        - sudo apt-get install openjdk-11-jdk -y
+        - export JAVA_HOME="/usr/lib/jvm/java-11-openjdk-amd64"
         - export PATH=${JAVA_HOME}/bin:$PATH
         - java -version
         - echo $JAVA_HOME

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Changes
 =======
 
+Beta 0.3.3
+----------
+Added functionality:
+* Added support for Miseq Control Software Version 3.1
+  * Use parser `miseq_v31`, behaves the same as miniseq and iseq parser.
+  * Also added `miseq_v26` to specify parsing for the older miseq control software.
+  * The `miseq` parser still specifies the Miseq Control Software Version 2.6
+
 Beta 0.3.2
 ----------
 Added functionality:

--- a/core/cli_entry.py
+++ b/core/cli_entry.py
@@ -9,7 +9,7 @@ from model import DirectoryStatus
 
 from . import api_handler, parsing_handler, logger, exit_return
 
-VERSION_NUMBER = "0.3.2"
+VERSION_NUMBER = "0.3.3"
 
 
 def upload_run_single_entry(directory, force_upload=False):

--- a/docs/index.md
+++ b/docs/index.md
@@ -94,9 +94,14 @@ We currently support the following:
 
 `directory` : [Generic Directory](parsers/directory.md)
 
-`miseq` : [Miseq](parsers/miseq.md)
+`miseq` / `miseq_v26` : [Miseq (Control Software Version 2.6)](parsers/miseq_v26.md)
 
-`miniseq` / `iseq` : [MiniSeq / iSeq](parsers/miniseq.md)
+`miseq_v31` : [Miseq (Control Software Version 3.1)](parsers/miseq_v31.md)
+
+`miniseq` : [MiniSeq](parsers/miniseq.md)
+
+`iseq` : [iSeq](parsers/miniseq.md)
+
 
 `nextseq` : [NextSeq](parsers/nextseq.md)
 

--- a/docs/parsers/directory.md
+++ b/docs/parsers/directory.md
@@ -1,3 +1,5 @@
+# Directory Upload
+
 ## File Structure
 
 To upload using the directory parser, Organize your files according to the following

--- a/docs/parsers/miniseq.md
+++ b/docs/parsers/miniseq.md
@@ -1,3 +1,5 @@
+# MiniSeq / iSeq
+
 ## File Structure
 
 The file structure for a miniseq / iseq run should be correct by default, but if you are having problems uploading, please verify your file structure is correct.

--- a/docs/parsers/miseq_v26.md
+++ b/docs/parsers/miseq_v26.md
@@ -1,3 +1,5 @@
+# MiSeq (Software Control Version 2.6)
+
 ## File Structure
 
 The file structure for a miseq run should be correct by default, but if you are having problems uploading, please verify your file structure is correct.

--- a/docs/parsers/miseq_v31.md
+++ b/docs/parsers/miseq_v31.md
@@ -1,0 +1,56 @@
+# MiSeq (Software Control Version 3.1)
+
+## File Structure
+
+The file structure for a MiSeq run when making fastq files should work by default, but if you are having problems uploading, please verify your file structure is correct.
+
+```
+.
+├── CompletedJobInfo.xml
+├── Alignment_1
+│   └── <DateTimeFolder>
+│       └── Fastq
+│           ├── sample1_S1_L001_R1_001.fastq.gz
+│           ├── sample1_S1_L001_R2_001.fastq.gz
+│           ├── sample2_S1_L001_R1_001.fastq.gz
+│           ├── sample2_S1_L001_R2_001.fastq.gz
+│           ├── sample3_S1_L001_R1_001.fastq.gz
+│           ├── sample3_S1_L001_R2_001.fastq.gz
+│           └── <other files>
+├── SampleSheet.csv
+└── <other files>
+```
+
+Example files can be found: `/example_sample_sheets/miniseq_run/`
+
+## Preparing your miseq sample sheet
+Before using the uploader, you must prepare your sequencing run with IRIDA-specific project IDs. You can either enter the project IDs when you're creating your sample sheet using the Illumina Experiment Manager or after creating the sample sheet by editing `SampleSheet.csv` with Microsoft Excel or Windows Notepad.
+
+An example, completed `SampleSheet.csv` with the `Sample_Project` column filled in looks like:
+
+```
+[Header]
+IEMFileVersion,4
+Investigator Name,Investigator 1
+Experiment Name,Experiment
+Date,2015-05-14
+Workflow,GenerateFASTQ
+Application,FASTQ Only
+Assay,Nextera XT
+Description,
+Chemistry,Amplicon
+
+[Reads]
+251
+251
+
+[Settings]
+ReverseComplement,0
+Adapter,ATCGATCGATCG
+
+[Data]
+Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description
+sample1,,plate1,A01,N801,ATCGAAA,S801,ATCGAAA,1,
+sample2,,plate1,A01,N801,ATCGAAA,S801,ATCGAAA,1,
+sample3,,plate1,A01,N801,ATCGAAA,S801,ATCGAAA,1,
+```

--- a/docs/parsers/nextseq.md
+++ b/docs/parsers/nextseq.md
@@ -1,3 +1,5 @@
+# NextSeq
+
 ## File Structure
 
 The file structure for a NextSeq run will need `bcl2fastq` run first to produce usable fastq files.

--- a/parsers/parsers.py
+++ b/parsers/parsers.py
@@ -4,6 +4,8 @@ from . import directory, miseq, miniseq, nextseq
 
 supported_parsers = [
     'miseq',
+    'miseq_v26',
+    'miseq_v31',
     'miniseq',
     'nextseq',
     'iseq',
@@ -41,11 +43,11 @@ class Parser:
         if parser_type == "directory":
             logging.debug("Creating directory parser")
             return directory.Parser()
-        if parser_type == "miseq":
-            logging.debug("Creating miseq parser")
+        if parser_type in ['miseq', 'miseq_v26']:
+            logging.debug("Creating miseq (v26) parser")
             return miseq.Parser()
-        if parser_type == "miniseq" or parser_type == "iseq":
-            logging.debug("Creating miniseq/iseq parser")
+        if parser_type in ['miniseq', 'iseq', 'miseq_v31']:
+            logging.debug("Creating miniseq/iseq/miseq_v31 parser")
             return miniseq.Parser()
         if parser_type == "nextseq":
             logging.debug("Creating nextseq parser")

--- a/tests_integration/integration_data_setup.py
+++ b/tests_integration/integration_data_setup.py
@@ -116,7 +116,9 @@ class SetupIridaData:
                 sleep(10)
 
     def start_driver(self):
-        self.driver = webdriver.Chrome()
+        options = webdriver.ChromeOptions()
+        options.headless = True
+        self.driver = webdriver.Chrome(options=options)
         self.driver.implicitly_wait(30)
 
     def login(self):

--- a/windows-gui-installer.cfg
+++ b/windows-gui-installer.cfg
@@ -1,6 +1,6 @@
 [Application]
 name=IRIDA Sequence Uploader GUI
-version=0.3.2
+version=0.3.3
 entry_point=upload_gui:main
 icon=gui/images/icon.ico
 # Uncomment this to have a console show alongside the application

--- a/windows-installer.cfg
+++ b/windows-installer.cfg
@@ -1,6 +1,6 @@
 [Application]
 name=IRIDA Sequence Uploader
-version=0.3.2
+version=0.3.3
 entry_point=upload_run:main
 icon=gui/images/icon.ico
 # We need to set this to get a console:


### PR DESCRIPTION
## Description of changes
* Added support for Miseq Control Software Version 3.1
  * Use parser `miseq_v31`, behaves the same as miniseq and iseq parser.
  * Also added `miseq_v26` to specify parsing for the older miseq control software.
  * The `miseq` parser still specifies the Miseq Control Software Version 2.6

## Related issue
N/A

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [x] CHANGELOG.md updated with information for new change.
* [ ] Tests added (or description of how to test) for any new features.
* [x] User documentation updated for UI or technical changes.
