### PR TITLE
Change sample id to sample name for metadata API calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@ Changes
 Beta 0.4.3
 ----------
 Developer changes:
-* Added method `get_metadata(self, sample_id, project_id)` to allow other metadata to be fetched from the `api` module
-* Added method `send_metadata(self, metadata, project_id, sample_id)` to allow other metadata to be sent using the `api` module
+* Added method `get_metadata(self, sample_name, project_id)` to allow other metadata to be fetched from the `api` module
+* Added method `send_metadata(self, metadata, project_id, sample_name)` to allow other metadata to be sent using the `api` module
 * Added model `Metadata` to support `send_metadata` method
 
 Beta 0.4.2

--- a/docs/developers/api.md
+++ b/docs/developers/api.md
@@ -67,9 +67,9 @@ project_id -- the id of the project the sample is on
 
 returns list of assemblies files dictionary for given sample_id
 
-#### get_metadata(self, sample_id, project_id)
+#### get_metadata(self, sample_name, project_id)
 API call to api/samples/sample_id/metadata
-We fetch the other metadata metrics through the sample id
+We fetch the other metadata metrics through the sample name and its id from the project
 
 **arguments:**
 
@@ -133,9 +133,9 @@ assemblies -- default:False -- upload as assemblies instead of regular sequence 
 
 unmodified json response from server.
 
-#### send_metadata(self, metadata, project_id, sample_id)
-Put request to add user metadata to specific sample id
-raises error if either project ID or sample ID found in Sample object
+#### send_metadata(self, metadata, project_id, sample_name)
+Put request to add user metadata to specific sample name in the project.
+Raises error if either project ID or sample name found in Sample object
 doesn't exist in irida
 
 **arguments:**
@@ -144,7 +144,7 @@ metadata -- Metadata object to send to irida
 
 project_id -- irida project identifier
 
-sample_id -- irida numberical sample id
+sample_name -- sample now in specific irida project
 
 **returns:**
 

--- a/docs/developers/api.md
+++ b/docs/developers/api.md
@@ -144,7 +144,7 @@ metadata -- Metadata object to send to irida
 
 project_id -- irida project identifier
 
-sample_name -- sample now in specific irida project
+sample_name -- sample name found in specified irida project
 
 **returns:**
 

--- a/docs/developers/objects.md
+++ b/docs/developers/objects.md
@@ -47,7 +47,7 @@ It also includes a `properties_dict` that is used to store meta data, and is fil
 
 The `Metadata` object defines and stores additional metadata for upload to IRIDA in a key-value dictionary.
 
-When using the API and the `send_metadata` method, an `Metadata` object must be passed to the method.
+When using the API and the `send_metadata` method, a `Metadata` object must be passed to the method.
 
 ## Other Objects
 

--- a/iridauploader/api/api_calls.py
+++ b/iridauploader/api/api_calls.py
@@ -477,16 +477,16 @@ class ApiCalls(object):
 
         return result
 
-    def get_metadata(self, sample_id, project_id):
+    def get_metadata(self, sample_name, project_id):
         """
         API call to api/samples/{sampleId}/metadata
         arguments:
-            sample_id
+            sample_name
             project_id
         returns list of metadata associated with sampleID
         """
 
-        logging.info("Getting metadata from sample ID '{}' found in project ID '{}'".format(sample_id, project_id))
+        logging.info("Getting metadata from sample name '{}' found in project ID '{}'".format(sample_name, project_id))
 
         try:
             project_url = self._get_link(self.base_url, "projects")
@@ -503,14 +503,14 @@ class ApiCalls(object):
         try:
             url = self._get_link(sample_url, "sample/metadata",
                                  target_dict={
-                                     "key": "identifier",
-                                     "value": sample_id
+                                     "key": "sampleName",
+                                     "value": sample_name
                                  })
             response = self._session.get(url)
 
         except StopIteration:
-            logging.error("The given sample doesn't exist: ".format(sample_id))
-            raise exceptions.IridaResourceError("The given sample ID doesn't exist", sample_id)
+            logging.error("The given sample name doesn't exist: ".format(sample_name))
+            raise exceptions.IridaResourceError("The given sample name doesn't exist", sample_name)
 
         result = response.json()["resource"]["metadata"]
 
@@ -660,17 +660,17 @@ class ApiCalls(object):
 
         return json_res
 
-    def send_metadata(self, metadata, project_id, sample_id):
+    def send_metadata(self, metadata, project_id, sample_name):
         """
         Put request to add metadata to specific sample ID
 
         :param metadata: Metadata object
         :param project_id: id of project sample id is in
-        :param sample_id: id of sample to add metadata to
+        :param sample_name: name of sample in project to add metadata to
         :return: json response from server
         """
 
-        logging.info("Adding metadata to sample '{}' found in project '{}' on IRIDA.".format(sample_id, project_id))
+        logging.info("Adding metadata to sample '{}' found in project '{}' on IRIDA.".format(sample_name, project_id))
 
         try:
             project_url = self._get_link(self.base_url, "projects")
@@ -687,13 +687,13 @@ class ApiCalls(object):
         try:
             url = self._get_link(sample_url, "sample/metadata",
                                  target_dict={
-                                     "key": "identifier",
-                                     "value": sample_id
+                                     "key": "sampleName",
+                                     "value": sample_name
                                  })
 
         except StopIteration:
-            logging.error("The given sample doesn't exist: ".format(sample_id))
-            raise exceptions.IridaResourceError("The given sample ID doesn't exist", sample_id)
+            logging.error("The given sample doesn't exist: ".format(sample_name))
+            raise exceptions.IridaResourceError("The given sample doesn't exist", sample_name)
 
         json_obj = json.dumps(metadata.get_uploadable_dict())
 

--- a/iridauploader/model/metadata.py
+++ b/iridauploader/model/metadata.py
@@ -8,10 +8,12 @@ Metadata defines and stores metadata in (key: value) pairs using a dictionary
 
 class Metadata:
 
-    def __init__(self, metadata=None):
+    def __init__(self, metadata=None, project_id=None, sample_name=None):
         if metadata is None:
             metadata = {}
         self._metadata = metadata
+        self._project_id = project_id
+        self._sample_name = sample_name
 
     @property
     def metadata(self):
@@ -20,6 +22,22 @@ class Metadata:
     @metadata.setter
     def metadata(self, metadata):
         self._metadata = metadata
+
+    @property
+    def project_id(self):
+        return self._project_id
+
+    @project_id.setter
+    def project_id(self, project_id):
+        self._project_id = project_id
+
+    @property
+    def sample_name(self):
+        return self._sample_name
+    
+    @sample_name.setter
+    def sample_name(self, sample_name):
+        self._sample_name = sample_name
 
     def add_metadata_entry(self, key, value):
         self._metadata[key] = value

--- a/iridauploader/model/metadata.py
+++ b/iridauploader/model/metadata.py
@@ -34,7 +34,7 @@ class Metadata:
     @property
     def sample_name(self):
         return self._sample_name
-    
+
     @sample_name.setter
     def sample_name(self, sample_name):
         self._sample_name = sample_name


### PR DESCRIPTION
## Description of changes
Changed the need to use the sample ID to just the sample name for the metadata API calls along with adding a bit more to the metadata object including the sample_name and project_id along with their other properties

## Related issue
None

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [x] CHANGELOG.md updated with information for new change.
* [ ] Tests added (or description of how to test) for any new features.
* [x] User documentation updated for UI or technical changes.
