### PR TITLE
fix validation errors not raising correctly in directory parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Changes:
   * Default is 0 KB
 * Added `minimum_file_size` option to the GUI as an ADVANCED option
 
+Bug fixes:
+* Fixed `directory` parser not raising validation errors (to display to user) when samplesheet file is malformed.
+
 Developer Changes:
 The following changes have been done to speed up extremely long REST requests, more api improvements should be expected in the future.
 * The following `api` module methods have been changed to accept `sample_id` instead of `sample_name` and `project_id`

--- a/iridauploader/parsers/directory/parser.py
+++ b/iridauploader/parsers/directory/parser.py
@@ -98,11 +98,15 @@ class Parser(BaseParser):
         try:
             if run_data_directory_file_list is not None:
                 sample_parser.verify_sample_sheet_file_names_in_file_list(sample_sheet, run_data_directory_file_list)
-        except exceptions.SequenceFileError as error:
+        except (exceptions.SequenceFileError, exceptions.SampleSheetError) as error:
             validation_result.add_error(error)
             logging.error("Errors occurred while building sequence run from sample sheet")
             raise exceptions.ValidationError("Errors occurred while building sequence run from sample sheet",
                                              validation_result)
+        except Exception as error:
+            validation_result.add_error(error)
+            logging.error("System error while building sequencing run")
+            raise exceptions.ValidationError("System error while building sequencing run", validation_result)
 
         # Build a list of sample objects from sample sheet
         try:
@@ -110,10 +114,14 @@ class Parser(BaseParser):
                 sample_list = sample_parser.build_sample_list_from_sample_sheet_no_verify(sample_sheet)
             else:
                 sample_list = sample_parser.build_sample_list_from_sample_sheet_with_abs_path(sample_sheet)
-        except exceptions.DirectoryError as error:
+        except (exceptions.DirectoryError, exceptions.SampleSheetError) as error:
             validation_result.add_error(error)
             logging.error("Errors occurred while parsing files")
             raise exceptions.ValidationError("Errors occurred while parsing files", validation_result)
+        except Exception as error:
+            validation_result.add_error(error)
+            logging.error("System error while parsing files")
+            raise exceptions.ValidationError("System error while parsing files", validation_result)
 
         # verify samples in sample_list are all of one type, either single or paired end
         if not sample_parser.only_single_or_paired_in_sample_list(sample_list):


### PR DESCRIPTION
## Description of changes
Added more thorough exception catches to the directory parsers main parsing functions. They now will correctly catch sample sheet and other errors to display to the user.

## Related issue
N/A

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [x] CHANGELOG.md updated with information for new change.
* [ ] Tests added (or description of how to test) for any new features.
* [ ] User documentation updated for UI or technical changes.
