### PR TITLE
fix double dash mistake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changes
 =======
 
+Beta 0.8.2
+---------
+Bug Fixes:
+* Fixed command line help text inconsistency
+
 Beta 0.8.1
 ---------
 Bug Fixes:

--- a/iridauploader/core/cli.py
+++ b/iridauploader/core/cli.py
@@ -20,7 +20,7 @@ DESCRIPTION = textwrap.dedent('''
 This program parses sequencing runs and uploads them to IRIDA.
 
 required arguments:
-  --d DIRECTORY, --directory DIRECTORY
+  -d DIRECTORY, --directory DIRECTORY
                         Location of sequencing run to upload.
                         Directory must be writable.
 ''')


### PR DESCRIPTION
## Description of changes
When the help text displayed it incorrectly said `--d DIRECTORY,...` instead of `-d DIRECTORY,...`