### PR TITLE
stop coverage job running on scheduled tasks, security issue

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -45,9 +45,9 @@ jobs:
     runs-on: ubuntu-20.04 #See pre-installed software at https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md
 
     steps:
-      - uses: actions/checkout@v2 #Checkout the project from git
+      - uses: actions/checkout@v3 #Checkout the project from git
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
       - name: Run pep8
@@ -57,9 +57,9 @@ jobs:
     runs-on: ubuntu-20.04 #See pre-installed software at https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md
 
     steps:
-      - uses: actions/checkout@v2 #Checkout the project from git
+      - uses: actions/checkout@v3 #Checkout the project from git
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.7
       - name: Run mkdocs

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -121,7 +121,7 @@ jobs:
           path: .coverage.integration${{ matrix.branch }}
 
   coverage:
-    if: !(github.event_name == 'schedule')
+    if: github.event_name != 'schedule'
     name: Coverage
     runs-on: ubuntu-latest
     needs: [build-unittests, build-irida-integration]

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -121,6 +121,7 @@ jobs:
           path: .coverage.integration${{ matrix.branch }}
 
   coverage:
+    if: !(github.event_name == 'schedule')
     name: Coverage
     runs-on: ubuntu-latest
     needs: [build-unittests, build-irida-integration]


### PR DESCRIPTION
## Description of changes
Prevent the coverage job from running on scheduled tasks, It is a security issue
Can be seen here: https://github.com/phac-nml/irida-uploader/actions/runs/4159625938

## Related issue
Link to the GitHub issue this pull request addresses using the `#issuenum` format.  If it completes an issue, use `Fixes #issuenum` to automatically close the issue.
N/A
## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [ ] CHANGELOG.md updated with information for new change.
* [ ] Tests added (or description of how to test) for any new features.
* [ ] User documentation updated for UI or technical changes.
