### PR TITLE
drop 3.6 support

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: False #Setting so that if one of the test suites fail, the other will continue
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10", 3.11]
+        python-version: [3.7, 3.8, 3.9, "3.10", 3.11]
 
     steps:
     - uses: actions/checkout@v3 #Checkout the project from git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Beta 0.9.2
 Bug Fixes:
 * [CRITICAL] Fixed use of deprecated urllib3 method to `allowed_methods`
 
+Developer Changes:
+* Dropped support for Python v3.6 as urllib3 no longer supports it
+
 Beta 0.9.1
 ----------
 Changes:

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,7 +49,7 @@ If you prefer to build the uploader from source code, please see the README on [
 
 ##### Command Line
 
-The IRIDA Uploader requires Python version 3.6 or newer
+The IRIDA Uploader requires Python version 3.7 or newer
 
     $ python3 --version
 

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     include_package_data=True,
-    # Test cases makes make it incompatible with pre 3.6
-    python_requires='>=3.6',
+    # urllib3 v2.0 requires >=3.7
+    python_requires='>=3.7',
 
 )


### PR DESCRIPTION
## Description of changes
Dropped support for Python v3.6 as urllib3 no longer supports it

https://github.com/urllib3/urllib3/releases/tag/2.0.0

## Related issue
N/A

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [x] CHANGELOG.md updated with information for new change.
* [ ] Tests added (or description of how to test) for any new features.
* [ ] User documentation updated for UI or technical changes.
