### PR TITLE
Compatibility fixes for IRIDA version 23.10.1

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -101,10 +101,10 @@ jobs:
           while ! mysqladmin ping -h"${{ env.MYSQL_HOST }}" -P"${{ env.MYSQL_PORT }}" --silent; do
             sleep 1
           done
-      - name: Set up JDK 11 # Installs java 11
+      - name: Set up JDK 17 # Installs java 17
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: 17
       - name: MySQL Setup (SUDO) # Sets ONLY_FULL_GROUP_BY flag and gives runner privileges over database
         run: |
           sudo mysql -e "SET GLOBAL sql_mode=(SELECT REPLACE(@@sql_mode,'ONLY_FULL_GROUP_BY',''));" -h ${{ env.MYSQL_HOST }} -P ${{ env.MYSQL_PORT }} -p${{ env.MYSQL_ROOT_PASSWORD }};

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ Features:
 Developer Changes:
 * Updated IRIDA's integration test java version from 11 to 17
 * Added a backoff of 30 seconds between IRIDA launching and SQL commands starting to allow the SQL DB to populate.
-* Updated SQL command to accomidate new `user_type` field on IRIDA's `client_details` table.
+* Updated SQL command to accommodate new `user_type` field on IRIDA's `client_details` table.
+* Update readthedocs compatibility
 
 Beta 0.9.2
 ----------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Features:
 Developer Changes:
 * Updated IRIDA's integration test java version from 11 to 17
 * Added a backoff of 30 seconds between IRIDA launching and SQL commands starting to allow the SQL DB to populate.
+* Updated SQL command to accomidate new `user_type` field on IRIDA's `client_details` table.
 
 Beta 0.9.2
 ----------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 Changes
 =======
 
+Beta 0.9.3
+----------
+Features:
+* Added `log_directory` config option to allow a user specified base directory to log in.
+
+Developer Changes:
+* Updated IRIDA's integration test java version from 11 to 17
+* Added a backoff of 30 seconds between IRIDA launching and SQL commands starting to allow the SQL DB to populate.
+
 Beta 0.9.2
 ----------
 Bug Fixes:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -35,6 +35,7 @@ The config file has the following fields:
   * backoff = 1 = [0.5, 1, 2, 4, 8, 16, 32, 64, 128, 256, ...]
   * backoff = 2 = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, ...]
   * backoff = 10 = [5, 10, 20, 40, 80, 160, 320, 640, 1280, 2560, ...]
+* `log_directory` : Accepts a String to set the base directory to log runs to. Logs will be put into a folder with their run directory name within this specified directory.
 
 ###Example
 ```

--- a/iridauploader/tests_integration/create_sequencer_client.sql
+++ b/iridauploader/tests_integration/create_sequencer_client.sql
@@ -4,4 +4,4 @@ INSERT INTO client_details_grant_types (client_details_id,grant_value) VALUES (1
 INSERT INTO client_details_scope (client_details_id,scope) VALUES (1,"read");
 INSERT INTO client_details_scope (client_details_id,scope) VALUES (1,"write");
 -- user -- password encryption of `password1`
-INSERT INTO user (`createdDate`, `modifiedDate`, `email`, `firstName`, `lastName`, `locale`, `password`, `phoneNumber`, `username`, `enabled`, `system_role`, `credentialsNonExpired`) VALUES (now(), now() , 'jeffrey.thiessen@phac-aspc.gc.ca', 'Jeffrey', 'Thiessen', 'en', '$2a$10$yvzFLxWA9m2wNQmHpJtWT.MRZv8qV8Mo3EMB6HTkDnUbi9aBrbWWW', '0000', 'jeff', 1, 'ROLE_ADMIN', 1);
+INSERT INTO user (`createdDate`, `modifiedDate`, `email`, `firstName`, `lastName`, `locale`, `password`, `phoneNumber`, `username`, `enabled`, `system_role`, `credentialsNonExpired`, `user_type`) VALUES (now(), now() , 'jeffrey.thiessen@phac-aspc.gc.ca', 'Jeffrey', 'Thiessen', 'en', '$2a$10$yvzFLxWA9m2wNQmHpJtWT.MRZv8qV8Mo3EMB6HTkDnUbi9aBrbWWW', '0000', 'jeff', 1, 'ROLE_ADMIN', 1, 'TYPE_LOCAL');

--- a/iridauploader/tests_integration/integration_data_setup.py
+++ b/iridauploader/tests_integration/integration_data_setup.py
@@ -112,7 +112,9 @@ class SetupIridaData:
         Adds a user and a client for api operations to IRIDA database
         :return:
         """
-        sleep(120)
+        # Allow the mysql db time to populate after first start
+        # This only is an issue if the machine executing the test is very fast.
+        sleep(30)
 
         db_update_proc = subprocess.Popen(self.IRIDA_DB_UPDATE, shell=True)
         proc_res = db_update_proc.wait()

--- a/iridauploader/tests_integration/integration_data_setup.py
+++ b/iridauploader/tests_integration/integration_data_setup.py
@@ -112,6 +112,8 @@ class SetupIridaData:
         Adds a user and a client for api operations to IRIDA database
         :return:
         """
+        sleep(120)
+
         db_update_proc = subprocess.Popen(self.IRIDA_DB_UPDATE, shell=True)
         proc_res = db_update_proc.wait()
 

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -5,10 +5,14 @@
 # Required
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+
 mkdocs:
   configuration: mkdocs.yml
 
 python:
-  version: 3.7
   install:
     - requirements: docs/requirements.txt


### PR DESCRIPTION
## Description of changes

Developer Changes:
* Updated IRIDA's integration test java version from 11 to 17
* Added a backoff of 30 seconds between IRIDA launching and SQL commands starting to allow the SQL DB to populate.
* Updated SQL command to accommodate new `user_type` field on IRIDA's `client_details` table.
* Update readthedocs compatibility

## Related issue
Link to the GitHub issue this pull request addresses using the `#issuenum` format.  If it completes an issue, use `Fixes #issuenum` to automatically close the issue.

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [x] CHANGELOG.md updated with information for new change.
* [ ] Tests added (or description of how to test) for any new features.
* [x] User documentation updated for UI or technical changes.
